### PR TITLE
Add statistical report menus

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -73,6 +73,7 @@ Manage the animals that visit our veterinarian
 
         # Menús
         'views/animals_menus.xml',
+        'views/statistics_views.xml',
 
         # Secuencias/otros
         'views/visit_sequence.xml',

--- a/views/statistics_views.xml
+++ b/views/statistics_views.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+  <data>
+
+    <!-- Root menu for statistical reports -->
+    <menuitem id="menu_statistics_root" name="Reportes" parent="menu_animals" sequence="90"/>
+
+    <!-- Visit statistics -->
+    <record id="action_visit_statistics" model="ir.actions.act_window">
+      <field name="name">Estadísticas de Visitas</field>
+      <field name="res_model">animal.visit</field>
+      <field name="view_mode">pivot,graph</field>
+    </record>
+    <menuitem id="menu_visit_statistics" name="Visitas" parent="menu_statistics_root" action="action_visit_statistics" sequence="10"/>
+
+    <!-- Vaccination statistics -->
+    <record id="action_vaccination_statistics" model="ir.actions.act_window">
+      <field name="name">Estadísticas de Vacunaciones</field>
+      <field name="res_model">animal.vaccination</field>
+      <field name="view_mode">pivot,graph</field>
+    </record>
+    <menuitem id="menu_vaccination_statistics" name="Vacunaciones" parent="menu_statistics_root" action="action_vaccination_statistics" sequence="20"/>
+
+  </data>
+</odoo>


### PR DESCRIPTION
## Summary
- add statistical reports menu under Vet root
- include actions for visit and vaccination statistics

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a649fe3b30832ba3477a31286e619a