### PR TITLE
Add surgery, sterilization, and deworming statistics

### DIFF
--- a/views/statistics_views.xml
+++ b/views/statistics_views.xml
@@ -21,5 +21,29 @@
     </record>
     <menuitem id="menu_vaccination_statistics" name="Vacunaciones" parent="menu_statistics_root" action="action_vaccination_statistics" sequence="20"/>
 
+    <!-- Surgery statistics -->
+    <record id="action_surgery_statistics" model="ir.actions.act_window">
+      <field name="name">Estadísticas de Cirugías</field>
+      <field name="res_model">animal.surgery</field>
+      <field name="view_mode">pivot,graph</field>
+    </record>
+    <menuitem id="menu_surgery_statistics" name="Cirugías" parent="menu_statistics_root" action="action_surgery_statistics" sequence="30"/>
+
+    <!-- Sterilization statistics -->
+    <record id="action_sterilization_statistics" model="ir.actions.act_window">
+      <field name="name">Estadísticas de Esterilizaciones</field>
+      <field name="res_model">animal.sterilization</field>
+      <field name="view_mode">pivot,graph</field>
+    </record>
+    <menuitem id="menu_sterilization_statistics" name="Esterilizaciones" parent="menu_statistics_root" action="action_sterilization_statistics" sequence="40"/>
+
+    <!-- Deworming statistics -->
+    <record id="action_deworming_statistics" model="ir.actions.act_window">
+      <field name="name">Estadísticas de Desparasitaciones</field>
+      <field name="res_model">animal.deworming</field>
+      <field name="view_mode">pivot,graph</field>
+    </record>
+    <menuitem id="menu_deworming_statistics" name="Desparasitaciones" parent="menu_statistics_root" action="action_deworming_statistics" sequence="50"/>
+
   </data>
 </odoo>


### PR DESCRIPTION
## Summary
- extend statistics menu with surgeries, sterilizations, and dewormings reports

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a64bc0bdfc832b9498de0a70f34a99