### PR TITLE
Agregar descripciones en español para App Store

### DIFF
--- a/vet_management/README.rst
+++ b/vet_management/README.rst
@@ -1,0 +1,19 @@
+Gestión Veterinaria
+===================
+
+Módulo para la gestión integral de clínicas veterinarias en Odoo 17.
+
+Características principales
+--------------------------
+* Registro de animales con especie, raza, alergias y propietarios.
+* Gestión de visitas médicas, vacunas, desparasitaciones y cirugías.
+* Control de recetas, consentimientos, seguros y sala de espera.
+* Reportes listos para impresión de visitas, esterilizaciones, recetas y más.
+
+Requisitos
+---------
+* Dependencias: ``base``, ``mail``.
+
+Licencia
+--------
+Este módulo se distribuye bajo la licencia OPL-1.

--- a/vet_management/__manifest__.py
+++ b/vet_management/__manifest__.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*- 
 {
-    'name': "Veterinary management",
+    'name': "Gestión Veterinaria",
 
-    'summary': "Manage the animals that visit our veterinarian",
+    'summary': "Gestiona los animales que visitan la veterinaria",
 
     'description': """
-Manage the animals that visit our veterinarian
+Gestiona los animales que visitan la veterinaria.
+Incluye visitas, vacunas, cirugías, recetas y más.
     """,
 
     'author': "z99sys",

--- a/vet_management/static/description/index.html
+++ b/vet_management/static/description/index.html
@@ -1,3 +1,18 @@
+<section class="oe_container oe_dark">
+    <div class="oe_row oe_spaced">
+        <h1 class="oe_slogan">Gestión Veterinaria</h1>
+        <p class="oe_mt32">
+            Administra pacientes, visitas médicas, vacunas y cirugías
+            desde un único lugar en Odoo.
+        </p>
+        <ul>
+            <li>Registro completo de animales y propietarios.</li>
+            <li>Control de visitas, recetas y consentimientos.</li>
+            <li>Reportes listos para imprimir.</li>
+        </ul>
+    </div>
+</section>
+
 <section class="oe_container">
     <div class="oe_row oe_spaced">
         <h3 class="oe_slogan">Formulario de Animal</h3>


### PR DESCRIPTION
## Summary
- Traducir y ampliar el manifiesto del módulo para describir funciones en español
- Añadir README en español con características clave y requisitos
- Ampliar la descripción HTML con texto en español e información funcional

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68acaa50f0b8832ba42a6dae16419cc3