### PR TITLE
Fix report module references

### DIFF
--- a/vet_management/report/consent_report.xml
+++ b/vet_management/report/consent_report.xml
@@ -20,9 +20,9 @@
       <field name="name">Consentimiento Informado</field>
       <field name="model">animal.consent</field>
       <field name="report_type">qweb-pdf</field>
-      <field name="report_name">vet.report_consent</field>
-      <field name="report_file">vet.report_consent</field>
-      <field name="paperformat_id" ref="vet.paperformat_consent_noheader"/>
+      <field name="report_name">vet_management.report_consent</field>
+      <field name="report_file">vet_management.report_consent</field>
+      <field name="paperformat_id" ref="vet_management.paperformat_consent_noheader"/>
       <field name="print_report_name">
         (object.sequence or 'Consentimiento') + ' - ' + (dict(object._fields['consent_type'].selection).get(object.consent_type) if object.consent_type else (object.consent_title or 'Documento')) + '.pdf'
       </field>
@@ -32,7 +32,7 @@
     <template id="report_consent">
       <t t-call="web.html_container">
         <t t-foreach="docs" t-as="doc">
-          <t t-call="vet.report_consent_document"/>
+          <t t-call="vet_management.report_consent_document"/>
           <div class="pagebreak"/>
         </t>
       </t>

--- a/vet_management/report/exam_order_report.xml
+++ b/vet_management/report/exam_order_report.xml
@@ -20,9 +20,9 @@
       <field name="name">Orden de Examen</field>
       <field name="model">animal.exam.order</field>
       <field name="report_type">qweb-pdf</field>
-      <field name="report_name">vet.report_exam_order</field>
-      <field name="report_file">vet.report_exam_order</field>
-      <field name="paperformat_id" ref="vet.paperformat_exam_order_noheader"/>
+      <field name="report_name">vet_management.report_exam_order</field>
+      <field name="report_file">vet_management.report_exam_order</field>
+      <field name="paperformat_id" ref="vet_management.paperformat_exam_order_noheader"/>
       <!-- Cambiamos el nombre del archivo según el estado:
            - Si está 'done' => "... - Resultado.pdf"
            - En cualquier otro estado => "... - Orden.pdf" -->
@@ -35,7 +35,7 @@
     <template id="report_exam_order">
       <t t-call="web.html_container">
         <t t-foreach="docs" t-as="doc">
-          <t t-call="vet.report_exam_order_document"/>
+          <t t-call="vet_management.report_exam_order_document"/>
           <div class="pagebreak"/>
         </t>
       </t>

--- a/vet_management/report/prescription_report.xml
+++ b/vet_management/report/prescription_report.xml
@@ -20,9 +20,9 @@
       <field name="name">Receta Veterinaria</field>
       <field name="model">animal.prescription</field>
       <field name="report_type">qweb-pdf</field>
-      <field name="report_name">vet.report_prescription</field>
-      <field name="report_file">vet.report_prescription</field>
-      <field name="paperformat_id" ref="vet.paperformat_prescription_noheader"/>
+      <field name="report_name">vet_management.report_prescription</field>
+      <field name="report_file">vet_management.report_prescription</field>
+      <field name="paperformat_id" ref="vet_management.paperformat_prescription_noheader"/>
       <field name="print_report_name">
         (object.sequence or 'Receta') + ' - ' + (object.animal_id and object.animal_id.name or 'Paciente') + '.pdf'
       </field>
@@ -32,7 +32,7 @@
     <template id="report_prescription">
       <t t-call="web.html_container">
         <t t-foreach="docs" t-as="doc">
-          <t t-call="vet.report_prescription_document"/>
+          <t t-call="vet_management.report_prescription_document"/>
           <div class="pagebreak"/>
         </t>
       </t>

--- a/vet_management/report/report_consent.py
+++ b/vet_management/report/report_consent.py
@@ -5,7 +5,7 @@ import base64
 
 
 class ReportConsent(models.AbstractModel):
-    _name = 'report.vet.report_consent'
+    _name = 'report.vet_management.report_consent'
     _description = 'Report Consent (PDF)'
 
     def _get_report_values(self, docids, data=None):
@@ -14,7 +14,7 @@ class ReportConsent(models.AbstractModel):
         header_b64 = False
         # Reutilizamos el header de "visita" si existe en el módulo
         try:
-            with file_open('vet/static/src/img/visita_header.png', 'rb') as f:
+            with file_open('vet_management/static/src/img/visita_header.png', 'rb') as f:
                 header_b64 = base64.b64encode(f.read()).decode('utf-8')
         except Exception:
             header_b64 = False
@@ -25,3 +25,4 @@ class ReportConsent(models.AbstractModel):
             'docs': docs,
             'consent_header_image': header_b64,
         }
+

--- a/vet_management/report/report_exam_order.py
+++ b/vet_management/report/report_exam_order.py
@@ -5,7 +5,7 @@ import base64
 
 
 class ReportExamOrder(models.AbstractModel):
-    _name = 'report.vet.report_exam_order'
+    _name = 'report.vet_management.report_exam_order'
     _description = 'Report Exam Order (PDF)'
 
     def _get_report_values(self, docids, data=None):
@@ -14,7 +14,7 @@ class ReportExamOrder(models.AbstractModel):
         header_b64 = False
         # Reutilizamos el header de "visita" si existe en el módulo
         try:
-            with file_open('vet/static/src/img/visita_header.png', 'rb') as f:
+            with file_open('vet_management/static/src/img/visita_header.png', 'rb') as f:
                 header_b64 = base64.b64encode(f.read()).decode('utf-8')
         except Exception:
             header_b64 = False

--- a/vet_management/report/report_prescription.py
+++ b/vet_management/report/report_prescription.py
@@ -5,7 +5,7 @@ import base64
 
 
 class ReportPrescription(models.AbstractModel):
-    _name = 'report.vet.report_prescription'
+    _name = 'report.vet_management.report_prescription'
     _description = 'Report Prescription (PDF)'
 
     def _get_report_values(self, docids, data=None):
@@ -14,7 +14,7 @@ class ReportPrescription(models.AbstractModel):
         header_b64 = False
         # Reutilizamos el header de "visita" si existe en el módulo
         try:
-            with file_open('vet/static/src/img/visita_header.png', 'rb') as f:
+            with file_open('vet_management/static/src/img/visita_header.png', 'rb') as f:
                 header_b64 = base64.b64encode(f.read()).decode('utf-8')
         except Exception:
             header_b64 = False

--- a/vet_management/report/report_sterilization.py
+++ b/vet_management/report/report_sterilization.py
@@ -4,7 +4,7 @@ from odoo.tools import file_open
 import base64
 
 class ReportSterilization(models.AbstractModel):
-    _name = 'report.vet.report_sterilization'
+    _name = 'report.vet_management.report_sterilization'
     _description = 'Report Sterilization (PDF)'
 
     def _get_report_values(self, docids, data=None):
@@ -13,9 +13,9 @@ class ReportSterilization(models.AbstractModel):
         img_b64 = False
         # Intentamos primero el header específico de esterilización
         paths_to_try = [
-            'vet/static/src/img/sterilizacion_header.png',
+            'vet_management/static/src/img/sterilizacion_header.png',
             # fallback por si se usa el mismo header de "visita"
-            'vet/static/src/img/visita_header.png',
+            'vet_management/static/src/img/visita_header.png',
         ]
         for p in paths_to_try:
             try:

--- a/vet_management/report/report_surgery.py
+++ b/vet_management/report/report_surgery.py
@@ -5,7 +5,7 @@ import base64
 
 
 class ReportSurgery(models.AbstractModel):
-    _name = 'report.vet.report_surgery'
+    _name = 'report.vet_management.report_surgery'
     _description = 'Report Surgery (PDF)'
 
     def _get_report_values(self, docids, data=None):
@@ -13,7 +13,7 @@ class ReportSurgery(models.AbstractModel):
 
         header_b64 = False
         try:
-            with file_open('vet/static/src/img/visita_header.png', 'rb') as f:
+            with file_open('vet_management/static/src/img/visita_header.png', 'rb') as f:
                 header_b64 = base64.b64encode(f.read()).decode('utf-8')
         except Exception:
             header_b64 = False

--- a/vet_management/report/report_vaccination.py
+++ b/vet_management/report/report_vaccination.py
@@ -5,7 +5,7 @@ import base64
 
 
 class ReportVaccination(models.AbstractModel):
-    _name = 'report.vet.report_vaccination'
+    _name = 'report.vet_management.report_vaccination'
     _description = 'Report Vaccination (PDF)'
 
     def _get_report_values(self, docids, data=None):
@@ -14,7 +14,7 @@ class ReportVaccination(models.AbstractModel):
         header_b64 = False
         # Reutilizamos el header de "visita" si existe en el módulo
         try:
-            with file_open('vet/static/src/img/visita_header.png', 'rb') as f:
+            with file_open('vet_management/static/src/img/visita_header.png', 'rb') as f:
                 header_b64 = base64.b64encode(f.read()).decode('utf-8')
         except Exception:
             header_b64 = False

--- a/vet_management/report/report_visit.py
+++ b/vet_management/report/report_visit.py
@@ -4,7 +4,7 @@ from odoo.tools import file_open
 import base64
 
 class ReportVisit(models.AbstractModel):
-    _name = 'report.vet.report_visit'
+    _name = 'report.vet_management.report_visit'
     _description = 'Report Visit (PDF)'
 
     def _get_report_values(self, docids, data=None):
@@ -15,13 +15,13 @@ class ReportVisit(models.AbstractModel):
 
         # Intentamos cargar ambas imágenes desde el módulo; si falla, seguimos sin romper el reporte
         try:
-            with file_open('vet/static/src/img/visita_header.png', 'rb') as f:
+            with file_open('vet_management/static/src/img/visita_header.png', 'rb') as f:
                 header_b64 = base64.b64encode(f.read()).decode('utf-8')
         except Exception:
             header_b64 = False
 
         try:
-            with file_open('vet/static/src/img/visita_divider.png', 'rb') as f:
+            with file_open('vet_management/static/src/img/visita_divider.png', 'rb') as f:
                 divider_b64 = base64.b64encode(f.read()).decode('utf-8')
         except Exception:
             divider_b64 = False

--- a/vet_management/report/sterilization_report.xml
+++ b/vet_management/report/sterilization_report.xml
@@ -22,10 +22,10 @@
       <field name="name">Ficha de Esterilización</field>
       <field name="model">animal.sterilization</field>
       <field name="report_type">qweb-pdf</field>
-      <field name="report_name">vet.report_sterilization</field>
-      <field name="report_file">vet.report_sterilization</field>
+      <field name="report_name">vet_management.report_sterilization</field>
+      <field name="report_file">vet_management.report_sterilization</field>
       <!-- Usamos el paperformat sin header -->
-      <field name="paperformat_id" ref="vet.paperformat_sterilization_noheader"/>
+      <field name="paperformat_id" ref="vet_management.paperformat_sterilization_noheader"/>
       <!-- Nombre dinámico del archivo -->
       <field name="print_report_name">
         (object.patient_name or 'Esterilizacion') + ' - Ficha.pdf'
@@ -36,7 +36,7 @@
     <template id="report_sterilization">
       <t t-call="web.html_container">
         <t t-foreach="docs" t-as="doc">
-          <t t-call="vet.report_sterilization_document"/>
+          <t t-call="vet_management.report_sterilization_document"/>
           <div class="pagebreak"/>
         </t>
       </t>

--- a/vet_management/report/surgery_report.xml
+++ b/vet_management/report/surgery_report.xml
@@ -20,9 +20,9 @@
       <field name="name">Acta Quirúrgica</field>
       <field name="model">animal.surgery.record</field>
       <field name="report_type">qweb-pdf</field>
-      <field name="report_name">vet.report_surgery</field>
-      <field name="report_file">vet.report_surgery</field>
-      <field name="paperformat_id" ref="vet.paperformat_surgery_noheader"/>
+      <field name="report_name">vet_management.report_surgery</field>
+      <field name="report_file">vet_management.report_surgery</field>
+      <field name="paperformat_id" ref="vet_management.paperformat_surgery_noheader"/>
       <field name="print_report_name">
         (object.sequence or 'Cirugia') + ' - ' + (object.animal_id and object.animal_id.name or 'Paciente') + '.pdf'
       </field>
@@ -32,7 +32,7 @@
     <template id="report_surgery">
       <t t-call="web.html_container">
         <t t-foreach="docs" t-as="doc">
-          <t t-call="vet.report_surgery_document"/>
+          <t t-call="vet_management.report_surgery_document"/>
           <div class="pagebreak"/>
         </t>
       </t>

--- a/vet_management/report/vaccination_report.xml
+++ b/vet_management/report/vaccination_report.xml
@@ -20,9 +20,9 @@
       <field name="name">Registro de Vacunación</field>
       <field name="model">animal.vaccination</field>
       <field name="report_type">qweb-pdf</field>
-      <field name="report_name">vet.report_vaccination</field>
-      <field name="report_file">vet.report_vaccination</field>
-      <field name="paperformat_id" ref="vet.paperformat_vaccination_noheader"/>
+      <field name="report_name">vet_management.report_vaccination</field>
+      <field name="report_file">vet_management.report_vaccination</field>
+      <field name="paperformat_id" ref="vet_management.paperformat_vaccination_noheader"/>
       <field name="print_report_name">
         (object.animal_id and object.animal_id.name or 'Vacunación') + ' - ' + (object.vaccine_id and object.vaccine_id.name or 'Vacuna') + ' - Registro.pdf'
       </field>
@@ -32,7 +32,7 @@
     <template id="report_vaccination">
       <t t-call="web.html_container">
         <t t-foreach="docs" t-as="doc">
-          <t t-call="vet.report_vaccination_document"/>
+          <t t-call="vet_management.report_vaccination_document"/>
           <div class="pagebreak"/>
         </t>
       </t>

--- a/vet_management/report/visit_report.xml
+++ b/vet_management/report/visit_report.xml
@@ -21,10 +21,10 @@
       <field name="name">Ficha Atención Veterinaria</field>
       <field name="model">animal.visit</field>
       <field name="report_type">qweb-pdf</field>
-      <field name="report_name">vet.report_visit</field>
-      <field name="report_file">vet.report_visit</field>
+      <field name="report_name">vet_management.report_visit</field>
+      <field name="report_file">vet_management.report_visit</field>
       <!-- Usamos el paperformat sin header -->
-      <field name="paperformat_id" ref="vet.paperformat_visit_noheader"/>
+      <field name="paperformat_id" ref="vet_management.paperformat_visit_noheader"/>
       <field name="print_report_name">
         (object.sequence or 'Visita') + ' - Ficha de Atención.pdf'
       </field>
@@ -34,7 +34,7 @@
     <template id="report_visit">
       <t t-call="web.html_container">
         <t t-foreach="docs" t-as="doc">
-          <t t-call="vet.report_visit_document"/>
+          <t t-call="vet_management.report_visit_document"/>
           <div class="pagebreak"/>
         </t>
       </t>

--- a/vet_management/views/prescriptions_views.xml
+++ b/vet_management/views/prescriptions_views.xml
@@ -61,7 +61,7 @@
                     type="object"
                     string="Cancelar"
                     invisible="[('state','not in',['draft','issued'])]"/>
-            <button name="%(vet.action_report_prescription)d"
+            <button name="%(action_report_prescription)d"
                     string="Imprimir Receta"
                     type="action"
                     class="btn-secondary"/>


### PR DESCRIPTION
## Summary
- use correct module prefix `vet_management` for report templates and paper formats
- adjust report parser classes and static asset paths to match module name
- fix prescription form view to reference report action from this module

## Testing
- `python -m py_compile $(git ls-files 'vet_management/report/*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68adde2fc058832b88e20e1ecb116122